### PR TITLE
【feature】質問一覧ページの実装 close #14

### DIFF
--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { Settings } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense } from "react";
 import { Routes } from "@/config";
 import { Pagination, QuestionList } from "@/features/questions/components";
 
@@ -12,22 +13,26 @@ const OrderBy = {
 };
 
 const QuestionsPage = () => {
-  const [orderBy, setOrderBy] = useState(OrderBy.NEW);
   const params = useSearchParams();
   const router = useRouter();
-
-  useEffect(() => {
-    setOrderBy(params.get("order") ? OrderBy.OLD : OrderBy.NEW);
-  }, [params]);
+  const page = params.get("page") || 1;
+  const nextParams = new URLSearchParams(params);
+  nextParams.set("page", Number(page) + 1);
 
   const handleOrderBy = (e) => {
     const query = new URLSearchParams(params);
+
     if (e.target.value === OrderBy.NEW) {
       query.delete("order");
     } else {
       query.set("order", OrderBy.OLD);
     }
-    router.push(Routes.questions + "?" + query.toString());
+
+    if (query.has("page")) {
+      query.delete("page");
+    }
+
+    router.push(`${Routes.questions}?${query.toString()}`);
   };
 
   return (
@@ -55,7 +60,7 @@ const QuestionsPage = () => {
                   type="radio"
                   name="order"
                   className="hidden"
-                  checked={orderBy === OrderBy.NEW ? true : false}
+                  checked={params.get("order") ? false : true}
                   onChange={handleOrderBy}
                   value={OrderBy.NEW}
                 />
@@ -66,7 +71,7 @@ const QuestionsPage = () => {
                   type="radio"
                   name="order"
                   className="hidden"
-                  checked={orderBy === OrderBy.OLD ? true : false}
+                  checked={params.get("order") === OrderBy.OLD ? true : false}
                   onChange={handleOrderBy}
                   value={OrderBy.OLD}
                 />
@@ -76,13 +81,13 @@ const QuestionsPage = () => {
           </div>
         </div>
 
-        <QuestionList />
+        <QuestionList url={`${Settings.API_URL}?${params.toString()}`} />
       </article>
 
       <Pagination />
 
       <div className="hidden">
-        <QuestionList />
+        <QuestionList url={`${Settings.API_URL}?${nextParams.toString()}`} />
       </div>
     </>
   );

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -3,9 +3,11 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
+import { Routes } from "@/config";
 
 const Data = Array.from({ length: 10 }, (_, i) => ({
   id: i,
+  uuid: `uuid${i}`,
   title: "redirect_toで編集画面への遷移がDELETEメソッドになってしまう",
   content:
     "ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト",
@@ -15,6 +17,7 @@ const Data = Array.from({ length: 10 }, (_, i) => ({
   user: {
     name: "名前",
     avatar: "",
+    uuid: `uuid${i}`,
   },
 }));
 
@@ -33,15 +36,16 @@ export default function Questions() {
   return (
     <>
       <article className="w-full">
-        <div className="flex w-full flex-col items-center justify-center gap-3">
+        <div className="flex w-full flex-col items-center justify-center gap-3 md:px-8 md:pt-4">
           <div className="flex w-full items-center justify-between">
-            <h1 className="text-xl">質問一覧ページ</h1>
-            <button
+            <h1 className="text-xl md:text-2xl">質問一覧ページ</h1>
+            <Link
+              href={Routes.questionsNew}
               type="button"
-              className="rounded bg-runteq-secondary px-2 py-1 text-white hover:bg-white hover:text-runteq-secondary"
+              className="rounded bg-runteq-secondary px-3 py-2 text-white transition-all hover:bg-white hover:text-runteq-secondary"
             >
               質問する
-            </button>
+            </Link>
           </div>
           <div className="flex w-full items-center justify-between ">
             <p className="text-sm">1000件の質問</p>
@@ -49,7 +53,7 @@ export default function Questions() {
               id="question-order"
               className="flex items-center justify-center gap-2 rounded border border-slate-400 bg-white px-2 py-1 text-sm"
             >
-              <label className="p-1">
+              <label className="cursor-pointer p-1">
                 <input
                   type="radio"
                   name="order"
@@ -60,7 +64,7 @@ export default function Questions() {
                 />
                 新着順
               </label>
-              <label className="p-1">
+              <label className="cursor-pointer p-1">
                 <input
                   type="radio"
                   name="order"
@@ -75,42 +79,59 @@ export default function Questions() {
           </div>
         </div>
 
-        <div className="my-4 rounded bg-white px-3">
+        <div className="my-4 rounded bg-white px-3 md:px-6 md:py-3">
           {Data.map((question, index) => (
             <section
               key={question.id}
               className={`flex items-start justify-center gap-2 py-4 ${index != Data.length - 1 && "border-b border-slate-300"}`}
             >
               <div className="flex flex-col items-center justify-center gap-1">
-                {question.user.avatar ? (
-                  <Image
-                    src={question.user.avatar}
-                    width={100}
-                    height={100}
-                    alt={question.user.name}
-                  />
-                ) : (
-                  <div className="size-16 rounded-full bg-orange-400" />
-                )}
-                <span className="text-sm">{question.user.name}</span>
+                <Link
+                  href={Routes.user(question.user.uuid)}
+                  className="transition-all hover:opacity-70"
+                >
+                  {question.user.avatar ? (
+                    <Image
+                      src={question.user.avatar}
+                      width={100}
+                      height={100}
+                      alt={question.user.name}
+                    />
+                  ) : (
+                    <div className="size-16 rounded-full bg-orange-400" />
+                  )}
+                </Link>
+                <Link
+                  href={Routes.user(question.user.uuid)}
+                  className="text-sm hover:underline"
+                >
+                  {question.user.name}
+                </Link>
               </div>
               <div className="grow">
-                <h2 className="text-lg text-blue-500 hover:text-opacity-70">
-                  {question.title}
+                <h2 className="text-lg text-blue-500">
+                  <Link
+                    href={Routes.question(question.uuid)}
+                    className="transition-all hover:underline hover:opacity-70"
+                  >
+                    {question.title}
+                  </Link>
                 </h2>
                 <p className="line-clamp-2 text-sm text-gray-600">
                   {question.content}
                 </p>
-                <div className="mt-2">
+                <div className="mt-2 md:flex md:items-end md:justify-between">
                   <div className="mb-2 flex items-center justify-start gap-1 text-sm">
-                    <span className="rounded bg-sky-400 px-2 py-1 text-white">
-                      {question.solved ? "解決済み" : "未解決"}
-                    </span>
+                    {question.solved && (
+                      <span className="rounded bg-sky-400 px-2 py-1 text-white">
+                        解決済み
+                      </span>
+                    )}
                     {question.tags.map((tag) => (
                       <Link
                         key={tag}
                         href="#"
-                        className="rounded bg-slate-400 px-2 py-1 text-white"
+                        className="rounded bg-slate-400 px-2 py-1 text-white transition-all hover:bg-slate-700 hover:text-white"
                       >
                         {tag}
                       </Link>
@@ -125,32 +146,32 @@ export default function Questions() {
           ))}
         </div>
       </article>
-      <article className="flex w-full items-center justify-center">
+      <article className="flex w-full items-center justify-center md:my-8 md:justify-start">
         <section className="text-sm text-runteq-secondary">
           <span className="rounded-l border border-runteq-secondary bg-runteq-secondary px-3 py-2 text-white">
             1
           </span>
           <Link
             href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2"
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
           >
             2
           </Link>
           <Link
             href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2 "
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
           >
             3
           </Link>
           <Link
             href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2 "
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
           >
             4
           </Link>
           <Link
             href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2 "
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
           >
             5
           </Link>
@@ -159,13 +180,13 @@ export default function Questions() {
           </span>
           <Link
             href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2 "
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
           >
             次へ
           </Link>
           <Link
             href="#"
-            className="rounded-r border border-slate-400 bg-white px-3 py-2 "
+            className="rounded-r border border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
           >
             最後
           </Link>

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -1,47 +1,31 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { Routes } from "@/config";
-
-const Data = Array.from({ length: 10 }, (_, i) => ({
-  id: i,
-  uuid: `uuid${i}`,
-  title: "redirect_toで編集画面への遷移がDELETEメソッドになってしまう",
-  content:
-    "ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト",
-  solved: i % 2 === 0,
-  tags: ["Ruby", "Rails"],
-  date: "2024/06/27 21:47",
-  user: {
-    name: "名前",
-    avatar: "",
-    uuid: `uuid${i}`,
-  },
-}));
+import { QuestionList } from "@/features/questions/components";
 
 const OrderBy = {
   NEW: "new",
   OLD: "old",
 };
 
-export default function Questions() {
+const QuestionsPage = () => {
   const [orderBy, setOrderBy] = useState(OrderBy.NEW);
-  const router = useRouter();
   const params = useSearchParams();
+  const router = useRouter();
 
   useEffect(() => {
-    setOrderBy(params.get("order_by") ? OrderBy.OLD : OrderBy.NEW);
+    setOrderBy(params.get("order") ? OrderBy.OLD : OrderBy.NEW);
   }, [params]);
 
   const handleOrderBy = (e) => {
-    let query = new URLSearchParams(params);
-    if (e.target.value === OrderBy.OLD) {
-      query.set("order_by", OrderBy.OLD);
+    const query = new URLSearchParams(params);
+    if (e.target.value === OrderBy.NEW) {
+      query.delete("order");
     } else {
-      query.delete("order_by");
+      query.set("order", OrderBy.OLD);
     }
     router.push(Routes.questions + "?" + query.toString());
   };
@@ -92,72 +76,7 @@ export default function Questions() {
           </div>
         </div>
 
-        <div className="my-4 rounded bg-white px-3 md:px-6 md:py-3">
-          {Data.map((question, index) => (
-            <section
-              key={question.id}
-              className={`flex items-start justify-center gap-2 py-4 ${index != Data.length - 1 && "border-b border-slate-300"}`}
-            >
-              <div className="flex flex-col items-center justify-center gap-1">
-                <Link
-                  href={Routes.user(question.user.uuid)}
-                  className="transition-all hover:opacity-70"
-                >
-                  {question.user.avatar ? (
-                    <Image
-                      src={question.user.avatar}
-                      width={100}
-                      height={100}
-                      alt={question.user.name}
-                    />
-                  ) : (
-                    <div className="size-16 rounded-full bg-orange-400" />
-                  )}
-                </Link>
-                <Link
-                  href={Routes.user(question.user.uuid)}
-                  className="text-sm hover:underline"
-                >
-                  {question.user.name}
-                </Link>
-              </div>
-              <div className="grow">
-                <h2 className="text-lg text-blue-500">
-                  <Link
-                    href={Routes.question(question.uuid)}
-                    className="transition-all hover:underline hover:opacity-70"
-                  >
-                    {question.title}
-                  </Link>
-                </h2>
-                <p className="line-clamp-2 text-sm text-gray-600">
-                  {question.content}
-                </p>
-                <div className="mt-2 md:flex md:items-end md:justify-between">
-                  <div className="mb-2 flex items-center justify-start gap-1 text-sm">
-                    {question.solved && (
-                      <span className="rounded bg-sky-400 px-2 py-1 text-white">
-                        解決済み
-                      </span>
-                    )}
-                    {question.tags.map((tag) => (
-                      <Link
-                        key={tag}
-                        href={Routes.questions + "?tag=" + tag}
-                        className="rounded bg-slate-400 px-2 py-1 text-white transition-all hover:bg-slate-700 hover:text-white"
-                      >
-                        {tag}
-                      </Link>
-                    ))}
-                  </div>
-                  <div className="text-end text-sm text-gray-400">
-                    {question.date}
-                  </div>
-                </div>
-              </div>
-            </section>
-          ))}
-        </div>
+        <QuestionList />
       </article>
       <article className="flex w-full items-center justify-center md:my-8 md:justify-start">
         <section className="text-sm text-runteq-secondary">
@@ -206,5 +125,13 @@ export default function Questions() {
         </section>
       </article>
     </>
+  );
+};
+
+export default function Questions() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <QuestionsPage />
+    </Suspense>
   );
 }

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -1,7 +1,176 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+
+const Data = Array.from({ length: 10 }, (_, i) => ({
+  id: i,
+  title: "redirect_toで編集画面への遷移がDELETEメソッドになってしまう",
+  content:
+    "ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト",
+  solved: i % 2 === 0,
+  tags: ["Ruby", "Rails"],
+  date: "2024/06/27 21:47",
+  user: {
+    name: "名前",
+    avatar: "",
+  },
+}));
+
+const OrderBy = {
+  NEW: "new",
+  OLD: "old",
+};
+
 export default function Questions() {
+  const [orderBy, setOrderBy] = useState(OrderBy.NEW);
+
+  const handleOrderBy = (e) => {
+    setOrderBy(e.target.value);
+  };
+
   return (
-    <article>
-      <h1>質問一覧ページ</h1>
-    </article>
+    <>
+      <article className="w-full">
+        <div className="flex w-full flex-col items-center justify-center gap-3">
+          <div className="flex w-full items-center justify-between">
+            <h1 className="text-xl">質問一覧ページ</h1>
+            <button
+              type="button"
+              className="rounded bg-runteq-secondary px-2 py-1 text-white hover:bg-white hover:text-runteq-secondary"
+            >
+              質問する
+            </button>
+          </div>
+          <div className="flex w-full items-center justify-between ">
+            <p className="text-sm">1000件の質問</p>
+            <div
+              id="question-order"
+              className="flex items-center justify-center gap-2 rounded border border-slate-400 bg-white px-2 py-1 text-sm"
+            >
+              <label className="p-1">
+                <input
+                  type="radio"
+                  name="order"
+                  className="hidden"
+                  checked={orderBy === OrderBy.NEW ? true : false}
+                  onChange={handleOrderBy}
+                  value={OrderBy.NEW}
+                />
+                新着順
+              </label>
+              <label className="p-1">
+                <input
+                  type="radio"
+                  name="order"
+                  className="hidden"
+                  checked={orderBy === OrderBy.OLD ? true : false}
+                  onChange={handleOrderBy}
+                  value={OrderBy.OLD}
+                />
+                古い順
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div className="my-4 rounded bg-white px-3">
+          {Data.map((question, index) => (
+            <section
+              key={question.id}
+              className={`flex items-start justify-center gap-2 py-4 ${index != Data.length - 1 && "border-b border-slate-300"}`}
+            >
+              <div className="flex flex-col items-center justify-center gap-1">
+                {question.user.avatar ? (
+                  <Image
+                    src={question.user.avatar}
+                    width={100}
+                    height={100}
+                    alt={question.user.name}
+                  />
+                ) : (
+                  <div className="size-16 rounded-full bg-orange-400" />
+                )}
+                <span className="text-sm">{question.user.name}</span>
+              </div>
+              <div className="grow">
+                <h2 className="text-lg text-blue-500 hover:text-opacity-70">
+                  {question.title}
+                </h2>
+                <p className="line-clamp-2 text-sm text-gray-600">
+                  {question.content}
+                </p>
+                <div className="mt-2">
+                  <div className="mb-2 flex items-center justify-start gap-1 text-sm">
+                    <span className="rounded bg-sky-400 px-2 py-1 text-white">
+                      {question.solved ? "解決済み" : "未解決"}
+                    </span>
+                    {question.tags.map((tag) => (
+                      <Link
+                        key={tag}
+                        href="#"
+                        className="rounded bg-slate-400 px-2 py-1 text-white"
+                      >
+                        {tag}
+                      </Link>
+                    ))}
+                  </div>
+                  <div className="text-end text-sm text-gray-400">
+                    {question.date}
+                  </div>
+                </div>
+              </div>
+            </section>
+          ))}
+        </div>
+      </article>
+      <article className="flex w-full items-center justify-center">
+        <section className="text-sm text-runteq-secondary">
+          <span className="rounded-l border border-runteq-secondary bg-runteq-secondary px-3 py-2 text-white">
+            1
+          </span>
+          <Link
+            href="#"
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2"
+          >
+            2
+          </Link>
+          <Link
+            href="#"
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2 "
+          >
+            3
+          </Link>
+          <Link
+            href="#"
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2 "
+          >
+            4
+          </Link>
+          <Link
+            href="#"
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2 "
+          >
+            5
+          </Link>
+          <span className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600 ">
+            ...
+          </span>
+          <Link
+            href="#"
+            className="border border-r-0 border-slate-400 bg-white px-3 py-2 "
+          >
+            次へ
+          </Link>
+          <Link
+            href="#"
+            className="rounded-r border border-slate-400 bg-white px-3 py-2 "
+          >
+            最後
+          </Link>
+        </section>
+      </article>
+    </>
   );
 }

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -2,7 +2,8 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import { Routes } from "@/config";
 
 const Data = Array.from({ length: 10 }, (_, i) => ({
@@ -28,9 +29,21 @@ const OrderBy = {
 
 export default function Questions() {
   const [orderBy, setOrderBy] = useState(OrderBy.NEW);
+  const router = useRouter();
+  const params = useSearchParams();
+
+  useEffect(() => {
+    setOrderBy(params.get("order_by") ? OrderBy.OLD : OrderBy.NEW);
+  }, [params]);
 
   const handleOrderBy = (e) => {
-    setOrderBy(e.target.value);
+    let query = { ...router.query, order_by: e.target.value };
+    if (e.target.value === OrderBy.NEW) {
+      delete query.order_by;
+    }
+    const url = new URL(window.location.href);
+    url.search = new URLSearchParams(query).toString();
+    router.push(url.toString());
   };
 
   return (

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -37,13 +37,13 @@ export default function Questions() {
   }, [params]);
 
   const handleOrderBy = (e) => {
-    let query = { ...router.query, order_by: e.target.value };
-    if (e.target.value === OrderBy.NEW) {
-      delete query.order_by;
+    let query = new URLSearchParams(params);
+    if (e.target.value === OrderBy.OLD) {
+      query.set("order_by", OrderBy.OLD);
+    } else {
+      query.delete("order_by");
     }
-    const url = new URL(window.location.href);
-    url.search = new URLSearchParams(query).toString();
-    router.push(url.toString());
+    router.push(Routes.questions + "?" + query.toString());
   };
 
   return (
@@ -143,7 +143,7 @@ export default function Questions() {
                     {question.tags.map((tag) => (
                       <Link
                         key={tag}
-                        href="#"
+                        href={Routes.questions + "?tag=" + tag}
                         className="rounded bg-slate-400 px-2 py-1 text-white transition-all hover:bg-slate-700 hover:text-white"
                       >
                         {tag}

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { Settings } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import useSWR from "swr";
-import { Routes } from "@/config";
+import { Routes, Settings } from "@/config";
 import { Pagination, QuestionList } from "@/features/questions/components";
 
 const OrderBy = {
@@ -22,7 +21,14 @@ const QuestionsPage = () => {
   const nextParams = new URLSearchParams(params);
   nextParams.set("page", Number(page) + 1);
   // TODO : 質問の総数を取得する。API側のURLは仮
-  const { data } = useSWR(`${Settings.API_URL}/questions_count`, fetcher, { fallbackData: { count: 500 } });
+  const { data } = useSWR(`${Settings.API_URL}/questions_count`, fetcher, {
+    fallbackData: { count: 500 },
+    onErrorRetry: (error) => {
+      if (error.status === 404) {
+        return;
+      }
+    },
+  });
 
   const handleOrderBy = (e) => {
     const query = new URLSearchParams(params);
@@ -86,13 +92,17 @@ const QuestionsPage = () => {
           </div>
         </div>
 
-        <QuestionList url={`${Settings.API_URL}?${params.toString()}`} />
+        <QuestionList
+          url={`${Settings.API_URL}/questions?${params.toString()}`}
+        />
       </article>
 
       <Pagination />
 
       <div className="hidden">
-        <QuestionList url={`${Settings.API_URL}?${nextParams.toString()}`} />
+        <QuestionList
+          url={`${Settings.API_URL}/questions?${nextParams.toString()}`}
+        />
       </div>
     </>
   );

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -4,6 +4,7 @@ import { Settings } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense } from "react";
+import useSWR from "swr";
 import { Routes } from "@/config";
 import { Pagination, QuestionList } from "@/features/questions/components";
 
@@ -12,12 +13,16 @@ const OrderBy = {
   OLD: "old",
 };
 
+const fetcher = (url) => fetch(url).then((res) => res.json());
+
 const QuestionsPage = () => {
   const params = useSearchParams();
   const router = useRouter();
   const page = params.get("page") || 1;
   const nextParams = new URLSearchParams(params);
   nextParams.set("page", Number(page) + 1);
+  // TODO : 質問の総数を取得する。API側のURLは仮
+  const { data } = useSWR(`${Settings.API_URL}/questions_count`, fetcher, { fallbackData: { count: 500 } });
 
   const handleOrderBy = (e) => {
     const query = new URLSearchParams(params);
@@ -50,7 +55,7 @@ const QuestionsPage = () => {
             </Link>
           </div>
           <div className="flex w-full items-center justify-between ">
-            <p className="text-sm">1000件の質問</p>
+            <p className="text-sm">{data.count}件の質問</p>
             <div
               id="question-order"
               className="flex items-center justify-center gap-2 rounded border border-slate-400 bg-white px-2 py-1 text-sm"

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { Routes } from "@/config";
-import { QuestionList } from "@/features/questions/components";
+import { Pagination, QuestionList } from "@/features/questions/components";
 
 const OrderBy = {
   NEW: "new",
@@ -78,52 +78,12 @@ const QuestionsPage = () => {
 
         <QuestionList />
       </article>
-      <article className="flex w-full items-center justify-center md:my-8 md:justify-start">
-        <section className="text-sm text-runteq-secondary">
-          <span className="rounded-l border border-runteq-secondary bg-runteq-secondary px-3 py-2 text-white">
-            1
-          </span>
-          <Link
-            href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-          >
-            2
-          </Link>
-          <Link
-            href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-          >
-            3
-          </Link>
-          <Link
-            href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-          >
-            4
-          </Link>
-          <Link
-            href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-          >
-            5
-          </Link>
-          <span className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600 ">
-            ...
-          </span>
-          <Link
-            href="#"
-            className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-          >
-            次へ
-          </Link>
-          <Link
-            href="#"
-            className="rounded-r border border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-          >
-            最後
-          </Link>
-        </section>
-      </article>
+
+      <Pagination />
+
+      <div className="hidden">
+        <QuestionList />
+      </div>
     </>
   );
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -74,3 +74,15 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* ============================= */
+/*        質問一覧ページ         */
+/* ============================= */
+#question-order > label {
+  border-radius: 4px;
+  padding: 3px 10px;
+  transition: all 0.15s;
+}
+#question-order > label:has(input:checked) {
+  background-color: rgb(202, 202, 202);
+}

--- a/src/features/questions/components/index.js
+++ b/src/features/questions/components/index.js
@@ -1,0 +1,3 @@
+import QuestionList from "./questionList";
+
+export { QuestionList };

--- a/src/features/questions/components/index.js
+++ b/src/features/questions/components/index.js
@@ -1,3 +1,4 @@
+import Pagination from "./pagination";
 import QuestionList from "./questionList";
 
-export { QuestionList };
+export { Pagination, QuestionList };

--- a/src/features/questions/components/pagination/index.jsx
+++ b/src/features/questions/components/pagination/index.jsx
@@ -1,0 +1,63 @@
+import { useRouter } from "next/navigation";
+import { Routes } from "@/config";
+
+export default function Pagination(currentPage, totalPage) {
+  const router = useRouter();
+
+  const handleClickPage = (page) => {
+    const query = new URLSearchParams(window.location.search);
+    if (page > 1) {
+      query.set("page", page);
+    }
+    router.push(Routes.questions + "?" + query.toString());
+  }
+
+  return (
+    <article className="flex w-full items-center justify-center md:my-8 md:justify-start">
+      <section className="text-sm text-runteq-secondary">
+        <span className="rounded-l border border-runteq-secondary bg-runteq-secondary px-3 py-2 text-white">
+          1
+        </span>
+        <button
+          onClick={() => handleClickPage(2)}
+          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+        >
+          2
+        </button>
+        <button
+          onClick={() => handleClickPage(3)}
+          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+        >
+          3
+        </button>
+        <button
+          onClick={() => handleClickPage(4)}
+          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+        >
+          4
+        </button>
+        <button
+          onClick={() => handleClickPage(5)}
+          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+        >
+          5
+        </button>
+        <span className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600 ">
+          ...
+        </span>
+        <button
+          onClick={() => handleClickPage(currentPage + 1)}
+          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+        >
+          次へ
+        </button>
+        <button
+          onClick={() => handleClickPage(totalPage)}
+          className="rounded-r border border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+        >
+          最後
+        </button>
+      </section>
+    </article>
+  );
+}

--- a/src/features/questions/components/pagination/index.jsx
+++ b/src/features/questions/components/pagination/index.jsx
@@ -15,9 +15,9 @@ export default function Pagination(currentPage, totalPage) {
   return (
     <article className="flex w-full items-center justify-center md:my-8 md:justify-start">
       <section className="text-sm text-runteq-secondary">
-        <span className="rounded-l border border-runteq-secondary bg-runteq-secondary px-3 py-2 text-white">
+        <button className="rounded-l border border-runteq-secondary bg-runteq-secondary px-3 py-2 text-white" disabled>
           1
-        </span>
+        </button>
         <button
           onClick={() => handleClickPage(2)}
           className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
@@ -42,9 +42,9 @@ export default function Pagination(currentPage, totalPage) {
         >
           5
         </button>
-        <span className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600 ">
+        <button className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600" disabled>
           ...
-        </span>
+        </button>
         <button
           onClick={() => handleClickPage(currentPage + 1)}
           className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"

--- a/src/features/questions/components/pagination/index.jsx
+++ b/src/features/questions/components/pagination/index.jsx
@@ -14,8 +14,12 @@ export default function Pagination(currentPage, totalPage) {
 
   return (
     <article className="flex w-full items-center justify-center md:my-8 md:justify-start">
+      {/* TODO : ページネーションの機能面含めた実装は別issue */}
       <section className="text-sm text-runteq-secondary">
-        <button className="rounded-l border border-runteq-secondary bg-runteq-secondary px-3 py-2 text-white" disabled>
+        <button
+          className="rounded-l border border-runteq-secondary bg-runteq-secondary px-3 py-2 text-white"
+          disabled
+        >
           1
         </button>
         <button
@@ -42,7 +46,10 @@ export default function Pagination(currentPage, totalPage) {
         >
           5
         </button>
-        <button className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600" disabled>
+        <button
+          className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600"
+          disabled
+        >
           ...
         </button>
         <button

--- a/src/features/questions/components/pagination/index.jsx
+++ b/src/features/questions/components/pagination/index.jsx
@@ -10,7 +10,7 @@ export default function Pagination(currentPage, totalPage) {
       query.set("page", page);
     }
     router.push(Routes.questions + "?" + query.toString());
-  }
+  };
 
   return (
     <article className="flex w-full items-center justify-center md:my-8 md:justify-start">

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -68,7 +68,7 @@ export default function QuestionList(url) {
                   {question.title}
                 </Link>
               </h2>
-              <p className="line-clamp-2 text-sm text-gray-600">
+              <p className="line-clamp-2 w-full max-w-[900px] text-sm text-gray-600">
                 {question.content}
               </p>
               <div className="mt-2 md:flex md:items-end md:justify-between">

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Routes } from "@/config";
+
+const Data = Array.from({ length: 10 }, (_, i) => ({
+  id: i,
+  uuid: `uuid${i}`,
+  title: "redirect_toで編集画面への遷移がDELETEメソッドになってしまう",
+  content:
+    "ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト",
+  solved: i % 2 === 0,
+  tags: ["Ruby", "Rails"],
+  date: "2024/06/27 21:47",
+  user: {
+    name: "名前",
+    avatar: "",
+    uuid: `uuid${i}`,
+  },
+}));
+
+export default function QuestionList() {
+  return (
+    <>
+      <div className="my-4 rounded bg-white px-3 md:px-6 md:py-3">
+        {Data.map((question, index) => (
+          <section
+            key={question.id}
+            className={`flex items-start justify-center gap-2 py-4 ${index != Data.length - 1 && "border-b border-slate-300"}`}
+          >
+            <div className="flex flex-col items-center justify-center gap-1">
+              <Link
+                href={Routes.user(question.user.uuid)}
+                className="transition-all hover:opacity-70"
+              >
+                {question.user.avatar ? (
+                  <Image
+                    src={question.user.avatar}
+                    width={100}
+                    height={100}
+                    alt={question.user.name}
+                  />
+                ) : (
+                  <div className="size-16 rounded-full bg-orange-400" />
+                )}
+              </Link>
+              <Link
+                href={Routes.user(question.user.uuid)}
+                className="text-sm hover:underline"
+              >
+                {question.user.name}
+              </Link>
+            </div>
+            <div className="grow">
+              <h2 className="text-lg text-blue-500">
+                <Link
+                  href={Routes.question(question.uuid)}
+                  className="transition-all hover:underline hover:opacity-70"
+                >
+                  {question.title}
+                </Link>
+              </h2>
+              <p className="line-clamp-2 text-sm text-gray-600">
+                {question.content}
+              </p>
+              <div className="mt-2 md:flex md:items-end md:justify-between">
+                <div className="mb-2 flex items-center justify-start gap-1 text-sm">
+                  {question.solved && (
+                    <span className="rounded bg-sky-400 px-2 py-1 text-white">
+                      解決済み
+                    </span>
+                  )}
+                  {question.tags.map((tag) => (
+                    <Link
+                      key={tag}
+                      href={Routes.questions + "?tag=" + tag}
+                      className="rounded bg-slate-400 px-2 py-1 text-white transition-all hover:bg-slate-700 hover:text-white"
+                    >
+                      {tag}
+                    </Link>
+                  ))}
+                </div>
+                <div className="text-end text-sm text-gray-400">
+                  {question.date}
+                </div>
+              </div>
+            </div>
+          </section>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import useSWR from "swr";
 import { Routes } from "@/config";
 
 const Data = Array.from({ length: 10 }, (_, i) => ({
@@ -9,7 +10,7 @@ const Data = Array.from({ length: 10 }, (_, i) => ({
   uuid: `uuid${i}`,
   title: "redirect_toで編集画面への遷移がDELETEメソッドになってしまう",
   content:
-    "ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト",
+    "ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト",
   solved: i % 2 === 0,
   tags: ["Ruby", "Rails"],
   date: "2024/06/27 21:47",
@@ -20,11 +21,17 @@ const Data = Array.from({ length: 10 }, (_, i) => ({
   },
 }));
 
-export default function QuestionList() {
+const fetcher = (url) => fetch(url).then((res) => res.json());
+
+export default function QuestionList(url) {
+  const { data } = useSWR(url, fetcher, { fallbackData: Data });
+
+  if (!data) return <div>loading...</div>
+
   return (
     <>
       <div className="my-4 rounded bg-white px-3 md:px-6 md:py-3">
-        {Data.map((question, index) => (
+        {data.map((question, index) => (
           <section
             key={question.id}
             className={`flex items-start justify-center gap-2 py-4 ${index != Data.length - 1 && "border-b border-slate-300"}`}
@@ -37,8 +44,8 @@ export default function QuestionList() {
                 {question.user.avatar ? (
                   <Image
                     src={question.user.avatar}
-                    width={100}
-                    height={100}
+                    width={64}
+                    height={64}
                     alt={question.user.name}
                   />
                 ) : (
@@ -74,7 +81,7 @@ export default function QuestionList() {
                   {question.tags.map((tag) => (
                     <Link
                       key={tag}
-                      href={Routes.questions + "?tag=" + tag}
+                      href={`${Routes.questions}?tag=${tag}`}
                       className="rounded bg-slate-400 px-2 py-1 text-white transition-all hover:bg-slate-700 hover:text-white"
                     >
                       {tag}

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -26,7 +26,7 @@ const fetcher = (url) => fetch(url).then((res) => res.json());
 export default function QuestionList(url) {
   const { data } = useSWR(url, fetcher, { fallbackData: Data });
 
-  if (!data) return <div>loading...</div>
+  if (!data) return <div>loading...</div>;
 
   return (
     <>

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -6,7 +6,6 @@ import useSWR from "swr";
 import { Routes } from "@/config";
 
 const Data = Array.from({ length: 10 }, (_, i) => ({
-  id: i,
   uuid: `uuid${i}`,
   title: "redirect_toで編集画面への遷移がDELETEメソッドになってしまう",
   content:
@@ -26,6 +25,7 @@ const fetcher = (url) => fetch(url).then((res) => res.json());
 export default function QuestionList(url) {
   const { data } = useSWR(url, fetcher, { fallbackData: Data });
 
+  // TODO : ローディング表示
   if (!data) return <div>loading...</div>;
 
   return (
@@ -88,9 +88,9 @@ export default function QuestionList(url) {
                     </Link>
                   ))}
                 </div>
-                <div className="text-end text-sm text-gray-400">
+                <time datetime={question.date} className="text-end text-sm text-gray-400">
                   {question.date}
-                </div>
+                </time>
               </div>
             </div>
           </section>

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -20,10 +20,26 @@ const Data = Array.from({ length: 10 }, (_, i) => ({
   },
 }));
 
-const fetcher = (url) => fetch(url).then((res) => res.json());
+const fetcher = async (url) => {
+  try {
+    const res = await fetch(url);
 
-export default function QuestionList(url) {
-  const { data } = useSWR(url, fetcher, { fallbackData: Data });
+    return res.json();
+  } catch (e) {
+    return Data;
+  }
+};
+
+export default function QuestionList({ url }) {
+  // TODO : 初期値はダミーデータ
+  const { data } = useSWR(url, fetcher, {
+    fallbackData: Data,
+    onErrorRetry: (error) => {
+      if (error.status === 404) {
+        return;
+      }
+    },
+  });
 
   // TODO : ローディング表示
   if (!data) return <div>loading...</div>;
@@ -33,7 +49,7 @@ export default function QuestionList(url) {
       <div className="my-4 rounded bg-white px-3 md:px-6 md:py-3">
         {data.map((question, index) => (
           <section
-            key={question.id}
+            key={index}
             className={`flex items-start justify-center gap-2 py-4 ${index != Data.length - 1 && "border-b border-slate-300"}`}
           >
             <div className="flex flex-col items-center justify-center gap-1">
@@ -88,7 +104,10 @@ export default function QuestionList(url) {
                     </Link>
                   ))}
                 </div>
-                <time datetime={question.date} className="text-end text-sm text-gray-400">
+                <time
+                  dateTime={question.date}
+                  className="text-end text-sm text-gray-400"
+                >
                   {question.date}
                 </time>
               </div>


### PR DESCRIPTION
# 概要
画面遷移図を元に質問一覧ページを作成しました。

## 確認ポイント
- [x] 質問するボタン
- [x] ソート用のボタン
- [x] ユーザー一覧用のカード
   - [x] ユーザー名
   - [x] タイトル
   - [x] 本文（文字数が多い場合は「...」とする）
   - [x] 投稿日時
- [x] ページネーションの表示
- [ ] サイドバーの表示
   - [ ] ホーム
   - [ ] 質問
   - [ ] タグ
   - [ ] 未解決

※サイドバーは環境構築時に実装済み

## 補足
サイドバーについてはMVP時点で必要なもののみ表示されている状態です。
質問一覧時に質問リンクが色つきの状態になるのは、コンフリクトの可能性を考えて今回は実装していません。
SWRでAPI通信まで実装していますが、連携がまだなので404エラーが出ます。404エラー時は再フェッチしないようにしています。

## 挙動
[PC](https://i.gyazo.com/5f975e8d28b87ddb3a6c1aaba102d190.mp4) / [SP](https://i.gyazo.com/8fd64346df3aee55769df7a6f6c534e5.mp4)
正常に表示できなかったのでリンクで失礼します