### PR TITLE
[feature] ログインユーザーの取得とカスタムフェッチの設定

### DIFF
--- a/src/app/(common)/layout.jsx
+++ b/src/app/(common)/layout.jsx
@@ -5,7 +5,7 @@ import { currentUserState } from "@/features/auth/api";
 
 export default function CommonRoot({ children }) {
   const currentUser = useRecoilValue(currentUserState);
-  const auth = currentUser.name === null ? false : true;
+  const auth = currentUser.uuid === null ? false : true;
 
   return (
     <>

--- a/src/app/(common)/layout.jsx
+++ b/src/app/(common)/layout.jsx
@@ -1,7 +1,11 @@
+"use client";
+import { useRecoilValue } from "recoil";
 import { Asides, Footers } from "@/components/layouts";
+import { currentUserState } from "@/features/auth/api";
 
 export default function CommonRoot({ children }) {
-  const auth = true; // TODO : 認証状態
+  const currentUser = useRecoilValue(currentUserState);
+  const auth = currentUser.name === null ? false : true;
 
   return (
     <>

--- a/src/app/(general)/auth/page.jsx
+++ b/src/app/(general)/auth/page.jsx
@@ -1,19 +1,5 @@
-"use client";
-import { useSearchParams } from "next/navigation";
-import { useEffect, Suspense } from "react";
-import { useAuth } from "@/hooks/useAuth";
-
-const Login = () => {
-  const params = useSearchParams();
-  const { setAccessToken } = useAuth();
-
-  useEffect(() => {
-    const token = params.get("token");
-    if (token) setAccessToken(token);
-  }, [params, setAccessToken]);
-
-  return null;
-};
+import { Suspense } from "react";
+import { Login } from "@/features/auth/api";
 
 export default function Auth() {
   return (

--- a/src/components/layouts/headers/index.jsx
+++ b/src/components/layouts/headers/index.jsx
@@ -1,7 +1,12 @@
+"use client";
 import Link from "next/link";
+import { useRecoilValue } from "recoil";
 import { Routes } from "@/config";
+import { currentUserState } from "@/features/auth/api";
 
 export default function Headers() {
+  const currentUser = useRecoilValue(currentUserState);
+
   return (
     <div className="flex justify-between md:container">
       <h1 className="flex items-center justify-center">
@@ -11,22 +16,25 @@ export default function Headers() {
       </h1>
       <nav className="relative w-full bg-white px-2">
         <ul className="flex w-full items-center justify-end py-4 text-xs md:text-base">
-          <li>
-            <Link
-              href={Routes.login}
-              className="px-2 py-4 transition-all hover:bg-runteq-primary   hover:text-white md:px-4"
-            >
-              ログイン
-            </Link>
-          </li>
-          <li>
-            <Link
-              href={Routes.user("uuid")}
-              className="px-2 py-4 transition-all  hover:bg-runteq-primary hover:text-white md:px-4"
-            >
-              ユーザーページ
-            </Link>
-          </li>
+          {!currentUser.github_uid ? (
+            <li>
+              <Link
+                href={Routes.login}
+                className="px-2 py-4 transition-all hover:bg-runteq-primary   hover:text-white md:px-4"
+              >
+                ログイン
+              </Link>
+            </li>
+          ) : (
+            <li>
+              <Link
+                href={Routes.user("uuid")}
+                className="px-2 py-4 transition-all  hover:bg-runteq-primary hover:text-white md:px-4"
+              >
+                ユーザーページ
+              </Link>
+            </li>
+          )}
         </ul>
       </nav>
     </div>

--- a/src/components/layouts/headers/index.jsx
+++ b/src/components/layouts/headers/index.jsx
@@ -16,7 +16,7 @@ export default function Headers() {
       </h1>
       <nav className="relative w-full bg-white px-2">
         <ul className="flex w-full items-center justify-end py-4 text-xs md:text-base">
-          {!currentUser.github_uid ? (
+          {!currentUser.uuid ? (
             <li>
               <Link
                 href={Routes.login}

--- a/src/components/layouts/headers/index.jsx
+++ b/src/components/layouts/headers/index.jsx
@@ -28,7 +28,7 @@ export default function Headers() {
           ) : (
             <li>
               <Link
-                href={Routes.user("uuid")}
+                href={Routes.user(currentUser.uuid)}
                 className="px-2 py-4 transition-all  hover:bg-runteq-primary hover:text-white md:px-4"
               >
                 ユーザーページ

--- a/src/features/auth/api/currentUserState/index.js
+++ b/src/features/auth/api/currentUserState/index.js
@@ -1,0 +1,14 @@
+"use client";
+import { atom } from "recoil";
+
+const currentUserState = atom({
+  key: "currentUserState",
+  default: {
+    name: null,
+    github_uid: null,
+    term: null,
+    profile: null,
+  },
+});
+
+export default currentUserState;

--- a/src/features/auth/api/currentUserState/index.js
+++ b/src/features/auth/api/currentUserState/index.js
@@ -4,6 +4,7 @@ import { atom } from "recoil";
 const currentUserState = atom({
   key: "currentUserState",
   default: {
+    uuid: null,
     name: null,
     github_uid: null,
     term: null,

--- a/src/features/auth/api/index.js
+++ b/src/features/auth/api/index.js
@@ -1,0 +1,4 @@
+import currentUserState from "./currentUserState";
+import Login from "./login";
+
+export { Login, currentUserState };

--- a/src/features/auth/api/login/index.js
+++ b/src/features/auth/api/login/index.js
@@ -16,13 +16,13 @@ const Login = () => {
     const token = params.get("token");
     if (token) {
       setAccessToken(token);
-      fetcher(`${Settings.API_URL}/auth/me`).then((data) => {
+      fetcher(`${Settings.API_URL}/auth/me`).then((current_user) => {
         setCurrentUser({
-          uuid: data.current_user.uuid,
-          name: data.current_user.name,
-          github_uid: data.current_user.github_uid,
-          term: data.current_user.term,
-          profile: data.current_user.profile,
+          uuid: current_user.uuid,
+          name: current_user.name,
+          github_uid: current_user.github_uid,
+          term: current_user.term,
+          profile: current_user.profile,
         });
       });
     }

--- a/src/features/auth/api/login/index.js
+++ b/src/features/auth/api/login/index.js
@@ -16,8 +16,9 @@ const Login = () => {
     const token = params.get("token");
     if (token) {
       setAccessToken(token);
-      fetcher(`${Settings.API_URL}/login`).then((data) => {
+      fetcher(`${Settings.API_URL}/auth/me`).then((data) => {
         setCurrentUser({
+          uuid: data.current_user.uuid,
           name: data.current_user.name,
           github_uid: data.current_user.github_uid,
           term: data.current_user.term,

--- a/src/features/auth/api/login/index.js
+++ b/src/features/auth/api/login/index.js
@@ -1,0 +1,32 @@
+"use client";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+import { useSetRecoilState } from "recoil";
+import { Settings } from "@/config";
+import { currentUserState } from "@/features/auth/api";
+import { useAuth } from "@/hooks/useAuth";
+import { fetcher } from "@/lib";
+
+const Login = () => {
+  const params = useSearchParams();
+  const { setAccessToken } = useAuth();
+  const setCurrentUser = useSetRecoilState(currentUserState);
+
+  useEffect(() => {
+    const token = params.get("token");
+    if (token) {
+      setAccessToken(token);
+      fetcher(`${Settings.API_URL}/login`).then((data) => {
+        setCurrentUser({
+          name: data.current_user.name,
+          github_uid: data.current_user.github_uid,
+          term: data.current_user.term,
+          profile: data.current_user.profile,
+        });
+      });
+    }
+  }, [params, setAccessToken, setCurrentUser]);
+  return null;
+};
+
+export default Login;

--- a/src/lib/fetcher/index.js
+++ b/src/lib/fetcher/index.js
@@ -1,0 +1,13 @@
+const fetcher = async (url) => {
+  const token = localStorage.getItem("access_token");
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return response.json();
+};
+
+export default fetcher;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,4 @@
+import fetcher from "./fetcher";
+import useFetchData from "./useFetchData";
+
+export { useFetchData, fetcher };

--- a/src/lib/useFetchData/index.js
+++ b/src/lib/useFetchData/index.js
@@ -1,0 +1,7 @@
+import useSWR from "swr";
+import { fetcher } from "@/lib";
+
+export default function useFetchData(url) {
+  const { data } = useSWR(url, fetcher);
+  return data;
+}


### PR DESCRIPTION
## 概要
githubのログイン後、自動的にログインユーザーの情報を取得する処理の作成を行いました。
カスタムフェッチの設定を行い、データフェッチ時の記載をできるだけ少なくなるように設定を行いました。

## 確認ポイント

- [x] ログインユーザー用のatom設定
  - [x] nameの設定がされているか
  - [x] github_uidの設定がされているか
  - [x] termの設定がされているか
  - [x] profileの設定がされているか
- [x] login関数の定義
  - [x] setCurrentUserStateにデータの設定を行っているか
  - [x] useEffectにてログイン後にデータのフェッチを行っているか
  - [x] エンドポイントを"/login"に設定しているか
- [x] fetcherの定義
  - [x] localstorageに保存されているデータからトークンを取得しているか
  - [x] urlを変更するだけでgetリクエストを送信できるか
- [x] useSWRを使用したデータフェッチ
  - [x] useSWRにてデータのフェッチが行えるか
- [x] commonページにてログイン状態かどうかによるレイアウトの変更ができているか
- [x] headerコンポーネントにてログイン状態かどうかによるレイアウトの変更ができているか

## 補足
recoilで設定してuseCurrentUserStateについては今後ユーザーページで使用すると考えられるname, github_uid, term, profileを設定しています。
適宜変更が必要であれば変更を行おうと思っております。
また、カスタムフェッチを設定しました。
```
例：　

import { useFetchData } from "@/lib"

const data = useFetchData(任意のurl)
```
とuseFetchDataをimportし上記のように記載することで、dataに取得したデータを保存できるようになっています。
