### PR TITLE
【fix】質問一覧のフェッチングをAPIと連携 close #15

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,5 @@
 import { Settings } from "./env";
+import { QuestionStatus } from "./questionStatus";
 import { Routes } from "./routes";
 
-export { Settings, Routes };
+export { Settings, Routes, QuestionStatus };

--- a/src/config/questionStatus/index.js
+++ b/src/config/questionStatus/index.js
@@ -1,4 +1,4 @@
 export const QuestionStatus = {
   OPEN: "open",
   CLOSE: "close",
-}
+};

--- a/src/config/questionStatus/index.js
+++ b/src/config/questionStatus/index.js
@@ -1,0 +1,4 @@
+export const QuestionStatus = {
+  OPEN: "open",
+  CLOSE: "close",
+}

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -2,44 +2,11 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import useSWR from "swr";
-import { Routes } from "@/config";
-
-const Data = Array.from({ length: 10 }, (_, i) => ({
-  uuid: `uuid${i}`,
-  title: "redirect_toで編集画面への遷移がDELETEメソッドになってしまう",
-  content:
-    "ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト",
-  solved: i % 2 === 0,
-  tags: ["Ruby", "Rails"],
-  date: "2024/06/27 21:47",
-  user: {
-    name: "名前",
-    avatar: "",
-    uuid: `uuid${i}`,
-  },
-}));
-
-const fetcher = async (url) => {
-  try {
-    const res = await fetch(url);
-
-    return res.json();
-  } catch (e) {
-    return Data;
-  }
-};
+import { QuestionStatus, Routes } from "@/config";
+import { useFetchData } from "@/lib";
 
 export default function QuestionList({ url }) {
-  // TODO : 初期値はダミーデータ
-  const { data } = useSWR(url, fetcher, {
-    fallbackData: Data,
-    onErrorRetry: (error) => {
-      if (error.status === 404) {
-        return;
-      }
-    },
-  });
+  const data = useFetchData(url);
 
   // TODO : ローディング表示
   if (!data) return <div>loading...</div>;
@@ -50,7 +17,7 @@ export default function QuestionList({ url }) {
         {data.map((question, index) => (
           <section
             key={index}
-            className={`flex items-start justify-center gap-2 py-4 ${index != Data.length - 1 && "border-b border-slate-300"}`}
+            className={`flex items-start justify-center gap-2 py-4 ${index != data.length - 1 && "border-b border-slate-300"}`}
           >
             <div className="flex flex-col items-center justify-center gap-1">
               <Link
@@ -89,12 +56,12 @@ export default function QuestionList({ url }) {
               </p>
               <div className="mt-2 md:flex md:items-end md:justify-between">
                 <div className="mb-2 flex items-center justify-start gap-1 text-sm">
-                  {question.solved && (
+                  {question.status === QuestionStatus.CLOSE && (
                     <span className="rounded bg-sky-400 px-2 py-1 text-white">
                       解決済み
                     </span>
                   )}
-                  {question.tags.map((tag) => (
+                  {question.tags?.map((tag) => (
                     <Link
                       key={tag}
                       href={`${Routes.questions}?tag=${tag}`}


### PR DESCRIPTION
# 概要
質問一覧をAPIから取得し表示しました。

# 確認ポイント
- [x] レイアウトに崩れてないか
- [x] データの表示

## 挙動
| PC | SP |
| :--: | :--: |
| <img src="https://i.gyazo.com/8345e8e64e425993188181b6bbd740bf.png" width="500px" /> | <img src="https://i.gyazo.com/de74cdd66c49f2480391ec553f92e0d0.png" width="200px" /> | 

## その他
seedデータを利用しているため、下記データがなく表示されていません。
- タグ ⇨ 未実装のため
- 質問内容 ⇨ 伝達し忘れ
- 質問日時 ⇨ 伝達し忘れ

## @gorilla-muscle さんへ
質問内容と質問更新日時のデータも必要でした。すみませんがご対応いただければ幸いです。
- 質問内容は全文ではなく2行ほど表示させる予定なので、300文字程度もあれば十分だと見ています
- 更新日時のフォーマットはAPI側で対応可能か確認したいです（フォーマット：`2024/07/27 17:27`といったもの）

## @miura-taiga さんへ
質問ステータスの設定を追加したのでご活用いただければと思います。