### PR TITLE
【feature】ページネーション機能 close #16

### DIFF
--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -2,17 +2,15 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense } from "react";
-import useSWR from "swr";
+import { Suspense, useEffect } from "react";
 import { Routes, Settings } from "@/config";
 import { Pagination, QuestionList } from "@/features/questions/components";
+import { useFetchData } from "@/lib";
 
 const OrderBy = {
   NEW: "new",
   OLD: "old",
 };
-
-const fetcher = (url) => fetch(url).then((res) => res.json());
 
 const QuestionsPage = () => {
   const params = useSearchParams();
@@ -20,14 +18,22 @@ const QuestionsPage = () => {
   const currentPage = params.get("page") || 1;
   const nextParams = new URLSearchParams(params);
   nextParams.set("page", Number(currentPage) + 1);
-  const { data } = useSWR(`${Settings.API_URL}/questions/all_count`, fetcher, {
-    fallbackData: { count: 500 },
-    onErrorRetry: (error) => {
-      if (error.status === 404) {
-        return;
-      }
-    },
-  });
+  const data = useFetchData(`${Settings.API_URL}/questions/all_count`);
+  const PER_PAGE = 10;
+  const TOTAL_PAGE = Math.ceil(data?.count / PER_PAGE);
+
+  useEffect(() => {
+    if (!params.get("page") || !data) return;
+
+    const query = new URLSearchParams(params);
+    if (Number(params.get("page")) > TOTAL_PAGE) {
+      query.set("page", TOTAL_PAGE);
+      router.push(`${Routes.questions}?${query.toString()}`);
+    } else if (Number(params.get("page")) <= 1) {
+      query.delete("page");
+      router.push(`${Routes.questions}?${query.toString()}`);
+    }
+  }, [params, router, data, TOTAL_PAGE]);
 
   const handleOrderBy = (e) => {
     const query = new URLSearchParams(params);
@@ -60,7 +66,7 @@ const QuestionsPage = () => {
             </Link>
           </div>
           <div className="flex w-full items-center justify-between ">
-            <p className="text-sm">{data.count}件の質問</p>
+            <p className="text-sm">{data?.count}件の質問</p>
             <div
               id="question-order"
               className="flex items-center justify-center gap-2 rounded border border-slate-400 bg-white px-2 py-1 text-sm"
@@ -91,18 +97,22 @@ const QuestionsPage = () => {
           </div>
         </div>
 
-        <QuestionList
-          url={`${Settings.API_URL}/questions?${params.toString()}`}
-        />
+        {currentPage > 0 && currentPage <= TOTAL_PAGE && (
+          <QuestionList
+            url={`${Settings.API_URL}/questions?${params.toString()}`}
+          />
+        )}
       </article>
 
-      <Pagination currentPage={Number(currentPage)} totalPage={Math.ceil(105 / 10)} />
+      <Pagination currentPage={Number(currentPage)} totalPage={TOTAL_PAGE} />
 
-      <div className="hidden">
-        <QuestionList
-          url={`${Settings.API_URL}/questions?${nextParams.toString()}`}
-        />
-      </div>
+      {currentPage < TOTAL_PAGE && (
+        <div className="hidden">
+          <QuestionList
+            url={`${Settings.API_URL}/questions?${nextParams.toString()}`}
+          />
+        </div>
+      )}
     </>
   );
 };

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -17,11 +17,10 @@ const fetcher = (url) => fetch(url).then((res) => res.json());
 const QuestionsPage = () => {
   const params = useSearchParams();
   const router = useRouter();
-  const page = params.get("page") || 1;
+  const currentPage = params.get("page") || 1;
   const nextParams = new URLSearchParams(params);
-  nextParams.set("page", Number(page) + 1);
-  // TODO : 質問の総数を取得する。API側のURLは仮
-  const { data } = useSWR(`${Settings.API_URL}/questions_count`, fetcher, {
+  nextParams.set("page", Number(currentPage) + 1);
+  const { data } = useSWR(`${Settings.API_URL}/questions/all_count`, fetcher, {
     fallbackData: { count: 500 },
     onErrorRetry: (error) => {
       if (error.status === 404) {
@@ -97,7 +96,7 @@ const QuestionsPage = () => {
         />
       </article>
 
-      <Pagination />
+      <Pagination currentPage={Number(currentPage)} totalPage={Math.ceil(105 / 10)} />
 
       <div className="hidden">
         <QuestionList

--- a/src/features/questions/components/pagination/index.jsx
+++ b/src/features/questions/components/pagination/index.jsx
@@ -32,30 +32,46 @@ export default function Pagination({ currentPage, totalPage }) {
             >
               前へ
             </button>
-            {
-              5 < currentPage && (
-                <button
-                  className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600"
-                  disabled
-                >
-                  ...
-                </button>
-              )
-            }
+            {5 < currentPage && (
+              <button
+                className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600"
+                disabled
+              >
+                ...
+              </button>
+            )}
           </>
         )}
 
         {/* ページ番号ボタン */}
-        {Array.from({ length: Math.min(10, totalPage) }, (_, i) => {
-          const page = currentPage - 2 + i;
+        {Array.from({ length: Math.min(5, totalPage) }, (_, i) => {
+          const page = currentPage - 4 + i;
           if (page > 0 && page <= totalPage) {
             return (
               <button
                 key={page}
                 onClick={() => handleClickPage(page)}
-                className={`border border-r-0 border-slate-400 px-3 py-2 ${currentPage === page ? "cursor-auto bg-runteq-secondary font-bold text-white" : "bg-white transition-all hover:bg-runteq-secondary hover:text-white"
-                  } ${currentPage == page && page == 1 && "rounded-l"} ${currentPage == page && currentPage == totalPage && "rounded-r"}`}
+                className={`border border-r-0 border-slate-400 px-3 py-2 ${
+                  currentPage === page
+                    ? "cursor-auto bg-runteq-secondary font-bold text-white"
+                    : "bg-white transition-all hover:bg-runteq-secondary hover:text-white"
+                } ${currentPage == page && page == 1 && "rounded-l"} ${currentPage == page && currentPage == totalPage && "rounded-r"}`}
                 disabled={currentPage === page}
+              >
+                {page}
+              </button>
+            );
+          }
+          return null;
+        })}
+        {Array.from({ length: Math.min(5, totalPage) }, (_, i) => {
+          const page = currentPage + i;
+          if (page > currentPage && page <= totalPage) {
+            return (
+              <button
+                key={page}
+                onClick={() => handleClickPage(page)}
+                className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
               >
                 {page}
               </button>
@@ -67,16 +83,14 @@ export default function Pagination({ currentPage, totalPage }) {
         {/* 次へと最後のボタン */}
         {currentPage < totalPage && (
           <>
-            {
-              currentPage + 5 < totalPage && (
-                <button
-                  className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600"
-                  disabled
-                >
-                  ...
-                </button>
-              )
-            }
+            {currentPage + 5 <= totalPage && (
+              <button
+                className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600"
+                disabled
+              >
+                ...
+              </button>
+            )}
             <button
               onClick={() => handleClickPage(currentPage + 1)}
               className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"

--- a/src/features/questions/components/pagination/index.jsx
+++ b/src/features/questions/components/pagination/index.jsx
@@ -1,69 +1,96 @@
 import { useRouter } from "next/navigation";
 import { Routes } from "@/config";
 
-export default function Pagination(currentPage, totalPage) {
+export default function Pagination({ currentPage, totalPage }) {
   const router = useRouter();
 
   const handleClickPage = (page) => {
     const query = new URLSearchParams(window.location.search);
     if (page > 1) {
       query.set("page", page);
+    } else {
+      query.delete("page");
     }
     router.push(Routes.questions + "?" + query.toString());
   };
 
   return (
     <article className="flex w-full items-center justify-center md:my-8 md:justify-start">
-      {/* TODO : ページネーションの機能面含めた実装は別issue */}
       <section className="text-sm text-runteq-secondary">
-        <button
-          className="rounded-l border border-runteq-secondary bg-runteq-secondary px-3 py-2 text-white"
-          disabled
-        >
-          1
-        </button>
-        <button
-          onClick={() => handleClickPage(2)}
-          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-        >
-          2
-        </button>
-        <button
-          onClick={() => handleClickPage(3)}
-          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-        >
-          3
-        </button>
-        <button
-          onClick={() => handleClickPage(4)}
-          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-        >
-          4
-        </button>
-        <button
-          onClick={() => handleClickPage(5)}
-          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-        >
-          5
-        </button>
-        <button
-          className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600"
-          disabled
-        >
-          ...
-        </button>
-        <button
-          onClick={() => handleClickPage(currentPage + 1)}
-          className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-        >
-          次へ
-        </button>
-        <button
-          onClick={() => handleClickPage(totalPage)}
-          className="rounded-r border border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
-        >
-          最後
-        </button>
+        {/* 最初と前へボタン */}
+        {currentPage > 1 && (
+          <>
+            <button
+              onClick={() => handleClickPage(1)}
+              className="rounded-l border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+            >
+              最初
+            </button>
+            <button
+              onClick={() => handleClickPage(currentPage - 1)}
+              className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+            >
+              前へ
+            </button>
+            {
+              5 < currentPage && (
+                <button
+                  className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600"
+                  disabled
+                >
+                  ...
+                </button>
+              )
+            }
+          </>
+        )}
+
+        {/* ページ番号ボタン */}
+        {Array.from({ length: Math.min(10, totalPage) }, (_, i) => {
+          const page = currentPage - 2 + i;
+          if (page > 0 && page <= totalPage) {
+            return (
+              <button
+                key={page}
+                onClick={() => handleClickPage(page)}
+                className={`border border-r-0 border-slate-400 px-3 py-2 ${currentPage === page ? "cursor-auto bg-runteq-secondary font-bold text-white" : "bg-white transition-all hover:bg-runteq-secondary hover:text-white"
+                  } ${currentPage == page && page == 1 && "rounded-l"} ${currentPage == page && currentPage == totalPage && "rounded-r"}`}
+                disabled={currentPage === page}
+              >
+                {page}
+              </button>
+            );
+          }
+          return null;
+        })}
+
+        {/* 次へと最後のボタン */}
+        {currentPage < totalPage && (
+          <>
+            {
+              currentPage + 5 < totalPage && (
+                <button
+                  className="border border-r-0 border-slate-400 bg-white px-3 py-2 text-gray-600"
+                  disabled
+                >
+                  ...
+                </button>
+              )
+            }
+            <button
+              onClick={() => handleClickPage(currentPage + 1)}
+              className="border border-r-0 border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+            >
+              次へ
+            </button>
+            <button
+              onClick={() => handleClickPage(totalPage)}
+              className="rounded-r border border-slate-400 bg-white px-3 py-2 transition-all hover:bg-runteq-secondary hover:text-white"
+            >
+              最後
+            </button>
+          </>
+        )}
       </section>
     </article>
   );

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -10,6 +10,7 @@ export default function QuestionList({ url }) {
 
   // TODO : ローディング表示
   if (!data) return <div>loading...</div>;
+  if (data.length === 0) return <div>質問がありません</div>;
 
   return (
     <>


### PR DESCRIPTION
# 概要
ページネーション機能を追加しました。
合計ページ数を越えるページを表示させようとした場合は最後のページを表示します
例：合計11ページなのに12ページ目を表示させようとすると11ページ目を表示する

## 挙動
[![Image from Gyazo](https://i.gyazo.com/048fa33ebe6ad7737595ef030a6f29b2.gif)](https://gyazo.com/048fa33ebe6ad7737595ef030a6f29b2)

## 確認ポイント
- [x] クエリパラメータの送信
- [x] ページ遷移用のリンクでの画面遷移

## 補足
ページ番号を表示する部分は、前ページ番号～現在のページ、現在のページ以降の2つに分けているので配列処理が2つに分かれています。
もしもっと良い方法ご存知でしたらご教示頂ければ幸いです。
また、shadcn/uiのページネーションはRUNTEQページのページネーションに合わせるのにコストが掛かりそうだったため使用していません