### PR TITLE
[fix] 認証時にURLがundefindになる件の修正

### DIFF
--- a/src/app/(general)/login/page.jsx
+++ b/src/app/(general)/login/page.jsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { FaGithub } from "rocketicons/fa";
 import { Settings } from "@/config";
 
@@ -7,13 +6,13 @@ export default function Login() {
     <article>
       <h1>ログインページ</h1>
       <div className="mt-16 flex items-center justify-center">
-        <Link
+        <a
           href={`${Settings.API_URL}/auth/github`}
           className="flex gap-2 rounded-md bg-black p-2 text-2xl text-white"
         >
           <FaGithub className="mb-1 inline-block size-8" />
           <span>GitHubでログイン</span>
-        </Link>
+        </a>
       </div>
     </article>
   );

--- a/src/app/(general)/login/page.jsx
+++ b/src/app/(general)/login/page.jsx
@@ -1,18 +1,22 @@
+"use client";
 import { FaGithub } from "rocketicons/fa";
 import { Settings } from "@/config";
 
 export default function Login() {
+  const handleGithhubAuth = () => {
+    window.location.href = `${Settings.API_URL}/auth/github`;
+  };
   return (
     <article>
       <h1>ログインページ</h1>
       <div className="mt-16 flex items-center justify-center">
-        <a
-          href={`${Settings.API_URL}/auth/github`}
+        <button
+          onClick={handleGithhubAuth}
           className="flex gap-2 rounded-md bg-black p-2 text-2xl text-white"
         >
           <FaGithub className="mb-1 inline-block size-8" />
           <span>GitHubでログイン</span>
-        </a>
+        </button>
       </div>
     </article>
   );


### PR DESCRIPTION
## 概要
認証時にバックエンド側にリクエストが飛ばずにURLがundefindになる問題の修正

## 備考
チェック実施済み

最初はaタグでの実装にしようかと思っておりましたが、公式のドキュメントにて外部リンクの場合はwindow.locationの使用が望ましいと言う記載がありましたので、そちらに変更しています。
[参考記事](https://nextjs-ja-translation-docs.vercel.app/docs/api-reference/next/router#routerpush)