### PR TITLE
QuestionDetailコンポーネントのタグ表示機能を追加

### DIFF
--- a/src/features/questions/components/questionDetail/index.jsx
+++ b/src/features/questions/components/questionDetail/index.jsx
@@ -6,6 +6,9 @@ import useFetchData from "@/lib/useFetchData";
 
 const QuestionDetail = ({ uuid }) => {
   const questionData = useFetchData(`${Settings.API_URL}/questions/${uuid}`);
+  const questionDataTags = useFetchData(
+    `${Settings.API_URL}/questions/${uuid}/tags`,
+  );
 
   useEffect(() => {
     import("zenn-embed-elements");
@@ -44,12 +47,12 @@ const QuestionDetail = ({ uuid }) => {
               </p> */}
             </div>
             <div className="mb-8">
-              {questionData.tags?.map((tag) => (
+              {questionDataTags?.map((tag) => (
                 <span
-                  key={tag}
+                  key={tag.id}
                   className="mr-2 rounded-lg bg-blue-500 px-2.5 py-0.5 text-xs font-semibold text-white"
                 >
-                  {tag}
+                  {tag.name}
                 </span>
               ))}
             </div>


### PR DESCRIPTION
## 概要

質問詳細回答ページにて質問に付属したタグのGET処理を行いました。

## 変更内容

`${Settings.API_URL}/questions/${uuid}/tags`のエンドポイントからtagデータを取得するリクエストを追加しました。

## 動作確認

[![Image from Gyazo](https://i.gyazo.com/1f1b9346a0ce6f9237cb8bff3d9672db.png)](https://gyazo.com/1f1b9346a0ce6f9237cb8bff3d9672db)

## 補足

- 今回はタグの表示のみを行なっています。タグの検索などが必要でしたら、別issueにて対応します。
- Loadingの処理はとぴさんのPRがマージされ次第、別途ブランチ切って対応する予定です。