### PR TITLE
【feature】タグの投稿機能と質問一覧にローディング表示 close #40

### DIFF
--- a/src/app/(auth)/questions/new/page.jsx
+++ b/src/app/(auth)/questions/new/page.jsx
@@ -23,14 +23,14 @@ export default function QuestionNew() {
 
     const submitId = e.nativeEvent.submitter.id;
     if (submitId === "POST") {
-      await postQuestion(title, body, token);
+      await postQuestion(title, body, token, tags);
     } else if (submitId === "REVIEW") {
       await reviewQuestion(title, body, token, tags);
     }
     setLoading(false);
   };
 
-  const postQuestion = async (title, body, token) => {
+  const postQuestion = async (title, body, token, tags) => {
     try {
       const response = await fetch(`${Settings.API_URL}/questions`, {
         method: "POST",
@@ -42,6 +42,7 @@ export default function QuestionNew() {
           question: {
             title,
             body,
+            tags,
           },
         }),
       });

--- a/src/app/(auth)/questions/page.jsx
+++ b/src/app/(auth)/questions/page.jsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect } from "react";
+import { Loading } from "@/components/layouts";
 import { Routes, Settings } from "@/config";
 import { Pagination, QuestionList } from "@/features/questions/components";
 import { useFetchData } from "@/lib";
@@ -134,7 +135,7 @@ const QuestionsPage = () => {
 
 export default function Questions() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<Loading />}>
       <QuestionsPage />
     </Suspense>
   );

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -2,14 +2,14 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { Loading } from "@/components/layouts";
 import { QuestionStatus, Routes } from "@/config";
 import { useFetchData } from "@/lib";
 
 export default function QuestionList({ url }) {
   const data = useFetchData(url);
 
-  // TODO : ローディング表示
-  if (!data) return <div>loading...</div>;
+  if (!data) return <Loading />;
   if (data.length === 0) return <div>質問がありません</div>;
 
   return (

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -65,10 +65,10 @@ export default function QuestionList({ url }) {
                   {question.tags?.map((tag) => (
                     <Link
                       key={tag}
-                      href={`${Routes.questions}?tag=${tag}`}
+                      href={`${Routes.questions}?tag=${tag.name}`}
                       className="rounded bg-slate-400 px-2 py-1 text-white transition-all hover:bg-slate-700 hover:text-white"
                     >
-                      {tag}
+                      {tag.name}
                     </Link>
                   ))}
                 </div>


### PR DESCRIPTION
# 概要
投稿時にタグを投稿できるようにしました。
一覧画面にてローディング画面を実装しました。
ローディング画面は[こちら](https://i.gyazo.com/8d21fc077886b4bf0f641d6e6c222524.mp4)で表示されているものと同じです。

## 補足
ブランチ分け忘れてタグの投稿機能も一緒になってしまいました。すみません。