### PR TITLE
質問一覧ページで画面幅による文字数の制限

### DIFF
--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -12,6 +12,25 @@ export default function QuestionList({ url }) {
   if (!data) return <Loading />;
   if (data.length === 0) return <div>質問がありません</div>;
 
+  const TextLimiter = ({ text }) => {
+    const getCharLimit = () => {
+      if (typeof window === 'undefined') return 70;
+
+      const width = window.innerWidth;
+      if (width < 600) return 10;
+      if (width < 1024) return 20;
+      if (width < 1920) return 40;
+      return 70;
+    };
+    const limit = getCharLimit();
+
+    const limitedText = text.length > limit
+      ? text.slice(0, limit) + '...'
+      : text;
+
+    return <>{limitedText}</>;
+  }
+
   return (
     <>
       <div className="rounded bg-white px-3 md:px-6 md:py-3">
@@ -26,7 +45,7 @@ export default function QuestionList({ url }) {
                 className="transition-all hover:opacity-70"
               >
                 {question.user.avatar &&
-                !question.user.avatar.endsWith("http://localhost:3000") ? (
+                  !question.user.avatar.endsWith("http://localhost:3000") ? (
                   <Image
                     src={question.user.avatar}
                     width={64}
@@ -52,11 +71,11 @@ export default function QuestionList({ url }) {
                   href={Routes.question(question.uuid)}
                   className="transition-all hover:underline hover:opacity-70"
                 >
-                  {question.title}
+                  <TextLimiter text={question.title} />
                 </Link>
               </h2>
               <p className="line-clamp-2 w-full max-w-[700px] truncate text-sm text-gray-600">
-                {question.body.slice(0, 70)}...
+                <TextLimiter text={question.body} />
               </p>
               <div className="mt-2 md:flex md:items-end md:justify-between">
                 <div className="mb-2 flex items-center justify-start gap-1 text-sm">

--- a/src/features/questions/components/questionList/index.jsx
+++ b/src/features/questions/components/questionList/index.jsx
@@ -14,7 +14,7 @@ export default function QuestionList({ url }) {
 
   const TextLimiter = ({ text }) => {
     const getCharLimit = () => {
-      if (typeof window === 'undefined') return 70;
+      if (typeof window === "undefined") return 70;
 
       const width = window.innerWidth;
       if (width < 600) return 10;
@@ -24,12 +24,11 @@ export default function QuestionList({ url }) {
     };
     const limit = getCharLimit();
 
-    const limitedText = text.length > limit
-      ? text.slice(0, limit) + '...'
-      : text;
+    const limitedText =
+      text.length > limit ? text.slice(0, limit) + "..." : text;
 
     return <>{limitedText}</>;
-  }
+  };
 
   return (
     <>
@@ -45,7 +44,7 @@ export default function QuestionList({ url }) {
                 className="transition-all hover:opacity-70"
               >
                 {question.user.avatar &&
-                  !question.user.avatar.endsWith("http://localhost:3000") ? (
+                !question.user.avatar.endsWith("http://localhost:3000") ? (
                   <Image
                     src={question.user.avatar}
                     width={64}


### PR DESCRIPTION
## 概要
質問一覧ページにて文字数が多い場合にレイアウトの崩れが生じていました。

## 修正内容
文字数の制限を関数にて設けることによりレイアウトの崩れを修正しました。

## キャプチャ
| モバイル | タブレット |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/974aac92dfc379defbe129230a8c7770.png)](https://gyazo.com/974aac92dfc379defbe129230a8c7770) | [![Image from Gyazo](https://i.gyazo.com/3fdd9c758902bf19a6059147f8e899ca.png)](https://gyazo.com/3fdd9c758902bf19a6059147f8e899ca) |

| mac | ディスプレイ |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/0d9cb310c31015f29bdd143618cc04b4.png)](https://gyazo.com/0d9cb310c31015f29bdd143618cc04b4) | [![Image from Gyazo](https://i.gyazo.com/8c75092253bc35ed53f098a0ba191e00.png)](https://gyazo.com/8c75092253bc35ed53f098a0ba191e00) |

## 補足
関数は質問一覧の表示機能以外で使用する場合が想定できなかったためコンポーネントに分離せずにquestionListに内包しています。