### PR TITLE
ユーザータブのレイアウト修正　close #77

### DIFF
--- a/src/app/(general)/page.jsx
+++ b/src/app/(general)/page.jsx
@@ -67,12 +67,16 @@ export default function Home() {
           <strong>runteq overflow</strong>{" "}
           は、アプリ開発における疑問点を掲示板形式で
           <strong>質問</strong>、<strong>回答</strong>、<strong>閲覧</strong>{" "}
-          できるサービスです。<br />
-          質問者は、回答者にわかりやすく質問するスキルを鍛える機会を得られます。<br />
-          また、自分の実装でうまくいかない部分を、過去の質問を参考にして解決することも可能です。<br />
+          できるサービスです。
+          <br />
+          質問者は、回答者にわかりやすく質問するスキルを鍛える機会を得られます。
+          <br />
+          また、自分の実装でうまくいかない部分を、過去の質問を参考にして解決することも可能です。
+          <br />
           さらに、質問に対して自分のわかる範囲で回答することで、
           <strong>Give</strong> の精神が身に付き、
-          誰かに教えることによって自分の記憶の定着にもつながります。<br />
+          誰かに教えることによって自分の記憶の定着にもつながります。
+          <br />
           <strong>質問者</strong>、<strong>回答者</strong>、
           <strong>閲覧者</strong> どの立場からもご利用いただけるサービスです。
           <p>
@@ -123,7 +127,10 @@ export default function Home() {
             </button>
           </Link>
         ) : (
-          <Link href="/login" className="mt-2 w-full rounded-lg bg-runteq-primary px-8 py-4 text-white transition-all hover:bg-[#D66200] sm:w-auto">
+          <Link
+            href="/login"
+            className="mt-2 w-full rounded-lg bg-runteq-primary px-8 py-4 text-white transition-all hover:bg-[#D66200] sm:w-auto"
+          >
             ログインする
           </Link>
         )}

--- a/src/components/form/questionTitle/index.jsx
+++ b/src/components/form/questionTitle/index.jsx
@@ -36,7 +36,9 @@ export default function QuestionTitle() {
           name="questionTags"
           className="mt-3 w-full rounded-lg border-gray-200 bg-gray-100 px-4 py-1 text-sm outline-none lg:text-base"
         />
-        <span className="text-xs text-red-400">「英数字」 「,」 「.」半角スペースのみ</span>
+        <span className="text-xs text-red-400">
+          「英数字」 「,」 「.」半角スペースのみ
+        </span>
       </div>
     </div>
   );

--- a/src/features/questions/components/questionDetail/index.jsx
+++ b/src/features/questions/components/questionDetail/index.jsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { useEffect } from "react";
 import markdownToHtml from "zenn-markdown-html";
-import { Routes , Settings } from "@/config";
+import { Routes, Settings } from "@/config";
 import * as Questions from "@/features/questions/components";
 import useFetchData from "@/lib/useFetchData";
 

--- a/src/features/users/components/profile/index.jsx
+++ b/src/features/users/components/profile/index.jsx
@@ -177,7 +177,14 @@ export default function Profile({ uuid }) {
           <div>
             <dl className="flex w-full flex-col">
               <div className="mb-2 w-full border-b pb-2">
-                <dt>勉強中{isEditing && (<span className="text-xs text-red-400">「英数字」「,」「.」半角スペースのみ</span>)}</dt>
+                <dt>
+                  勉強中
+                  {isEditing && (
+                    <span className="text-xs text-red-400">
+                      「英数字」「,」「.」半角スペースのみ
+                    </span>
+                  )}
+                </dt>
                 {isEditing ? (
                   <input
                     type="text"
@@ -203,7 +210,14 @@ export default function Profile({ uuid }) {
                 )}
               </div>
               <div className="w-full">
-                <dt>開発経験{isEditing && (<span className="text-xs text-red-400">「英数字」「,」「.」半角スペースのみ</span>)}</dt>
+                <dt>
+                  開発経験
+                  {isEditing && (
+                    <span className="text-xs text-red-400">
+                      「英数字」「,」「.」半角スペースのみ
+                    </span>
+                  )}
+                </dt>
                 {isEditing ? (
                   <input
                     type="text"

--- a/src/features/users/components/userQuestionList/index.jsx
+++ b/src/features/users/components/userQuestionList/index.jsx
@@ -46,7 +46,7 @@ export default function UserQuestionList({ uuid }) {
             <button
               type="button"
               onClick={() => handleTabChange(Tabs.question)}
-              className={`w-full rounded-t border-t-2 bg-white py-2 ${currentTab === Tabs.question ? " border-runteq-primary font-semibold text-runteq-primary" : "border-gray-400 bg-gray-400 text-white"}`}
+              className={`w-full rounded-t border-t-2 bg-white py-2 ${currentTab === Tabs.question ? "border-runteq-primary font-semibold text-runteq-primary" : "border-gray-400 bg-gray-400 text-gray-400"}`}
             >
               質問
             </button>
@@ -55,7 +55,7 @@ export default function UserQuestionList({ uuid }) {
             <button
               type="button"
               onClick={() => handleTabChange(Tabs.answer)}
-              className={`w-full rounded-t bg-white py-2 ${currentTab === Tabs.answer ? "border-t-2 border-runteq-primary font-semibold text-runteq-primary" : "border-gray-400 bg-gray-400 text-white"}`}
+              className={`w-full rounded-t border-t-2 bg-white py-2 ${currentTab === Tabs.answer ? "border-runteq-primary font-semibold text-runteq-primary" : "border-gray-400 bg-gray-400 text-gray-400"}`}
             >
               回答
             </button>

--- a/src/features/users/components/userQuestionList/index.jsx
+++ b/src/features/users/components/userQuestionList/index.jsx
@@ -46,7 +46,7 @@ export default function UserQuestionList({ uuid }) {
             <button
               type="button"
               onClick={() => handleTabChange(Tabs.question)}
-              className={`w-full rounded-t border-t-2 bg-white py-2 ${currentTab === Tabs.question ? "border-runteq-primary font-semibold text-runteq-primary" : "border-gray-400 bg-gray-400 text-gray-400"}`}
+              className={`w-full rounded-t border-t-2 py-2 ${currentTab === Tabs.question ? "bg-white border-runteq-primary font-semibold text-runteq-primary" : "border-gray-400 bg-gray-400 text-white"}`}
             >
               質問
             </button>
@@ -55,7 +55,7 @@ export default function UserQuestionList({ uuid }) {
             <button
               type="button"
               onClick={() => handleTabChange(Tabs.answer)}
-              className={`w-full rounded-t border-t-2 bg-white py-2 ${currentTab === Tabs.answer ? "border-runteq-primary font-semibold text-runteq-primary" : "border-gray-400 bg-gray-400 text-gray-400"}`}
+              className={`w-full rounded-t border-t-2 py-2 ${currentTab === Tabs.answer ? "bg-white border-runteq-primary font-semibold text-runteq-primary" : "border-gray-400 bg-gray-400 text-white"}`}
             >
               回答
             </button>


### PR DESCRIPTION
## 概要
ユーザーページにおける表示の修正を行いました。

## 確認事項

- [x] ユーザーページにてアクティブでないボタンのレイアウトが正しく表示されているか

## キャプチャ
[![Image from Gyazo](https://i.gyazo.com/be8b4c4fbca3c5355b8296d3f4107123.gif)](https://gyazo.com/be8b4c4fbca3c5355b8296d3f4107123)

## 補足事項
こちらもformatで修正が起きています。
お手数おかけしますが、`src/features/users/components/userQuestionList/index.jsx`を確認してください。