### PR TITLE
質問詳細画面にてレイアウトが崩れてしまう問題を修正

### DIFF
--- a/src/app/(auth)/questions/[uuid]/page.jsx
+++ b/src/app/(auth)/questions/[uuid]/page.jsx
@@ -10,7 +10,7 @@ export default function QuestionPage({ params }) {
   const { uuid } = params;
 
   return (
-    <article>
+    <article className="max-w-[1000px]">
       <QuestionDetail uuid={uuid} />
       <CommentsSection uuid={uuid} />
       <CommentForm uuid={uuid} />


### PR DESCRIPTION
## 問題
質問詳細画面にて原因不明のレイアウト崩れが発生してしまう。
問題の原因としてZennのマークダウンが考えられる（質問投稿画面で同じような問題が発生していたため）

## 確認事項
max-widthを設定することで上記の問題を解決できているか

## キャプチャ
| レイアウト崩れ | 解決後 |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/58b230cf5ad8500c87153909113763ce.png)](https://gyazo.com/58b230cf5ad8500c87153909113763ce) | [![Image from Gyazo](https://i.gyazo.com/724ab05086b972f64430232dd1c20944.png)](https://gyazo.com/724ab05086b972f64430232dd1c20944) |

#### 念の為修正した画面の全体をキャプチャ
[![Image from Gyazo](https://i.gyazo.com/0f2b9d8722ea4f32417d3225fa974434.png)](https://gyazo.com/0f2b9d8722ea4f32417d3225fa974434)

## 補足
問題の再現が行えなかったため、検証ツールにて解決した内容を添付しました。
実装としては同じ内容の実装を追加しています。

あくまで、macの環境で運用できるための応急処置的な修正です。
画像が小さくなっていそうであれば、修正します。