### PR TITLE
質問編集画面の作成　close #82

### DIFF
--- a/src/features/questions/components/questionDetail/index.jsx
+++ b/src/features/questions/components/questionDetail/index.jsx
@@ -1,11 +1,18 @@
 import Link from "next/link";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import markdownToHtml from "zenn-markdown-html";
 import { Routes, Settings } from "@/config";
 import * as Questions from "@/features/questions/components";
 import useFetchData from "@/lib/useFetchData";
+import { currentUserState } from "@/features/auth/api";
+import { useRecoilValue } from "recoil";
+import { resizeTextArea } from "@/utils";
+import { mutate } from "swr";
 
 const QuestionDetail = ({ uuid }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const currentUser = useRecoilValue(currentUserState);
+
   const questionData = useFetchData(`${Settings.API_URL}/questions/${uuid}`);
   const questionDataTags = useFetchData(
     `${Settings.API_URL}/questions/${uuid}/tags`,
@@ -23,6 +30,45 @@ const QuestionDetail = ({ uuid }) => {
     embedOrigin: "https://embed.zenn.studio",
   });
 
+  const handleEdit = () => {
+    setIsEditing(!isEditing);
+  };
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    const title = formData.get("title");
+    const tags = formData.get("tags").split(",")
+    const body = formData.get("body");
+
+    const updateData = {
+      title: title,
+      tags: tags,
+      body: body,
+    }
+
+    const token = localStorage.getItem("access_token");
+    const response = await fetch(`${Settings.API_URL}/questions/${uuid}`, {
+      method: "PATCH",
+      body: JSON.stringify({ question: updateData }),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (response.ok) {
+      setIsEditing(false);
+      const data = await response.json();
+      console.log(data);
+      mutate(`${Settings.API_URL}/questions/${uuid}`);
+      mutate(`${Settings.API_URL}/questions/${uuid}/tags`)
+    } else {
+      alert("エラーが発生しました");
+    }
+  };
+
+
   return (
     <div className="container relative mx-auto p-4">
       {questionData.status === "close" ? (
@@ -34,41 +80,104 @@ const QuestionDetail = ({ uuid }) => {
         <div className="mb-4 flex flex-col sm:flex-row">
           <Questions.UserAvatar user={questionData.user} />
           <div className="ml-0 mt-4 flex w-full flex-col sm:ml-8 sm:mt-0">
-            <h1 className="text-2xl font-bold">{questionData.title}</h1>
-            <div className="mb-2 mt-4 flex w-full flex-wrap border-b border-gray-300 pb-2 sm:mt-8">
+            {isEditing ? (
+              <input
+                type="text"
+                form="questionEditForm"
+                name="title"
+                defaultValue={questionData.title}
+                className="w-full flex-1 rounded border-b border-gray-200 px-4 py-2 pr-20 outline-none lg:text-xl"
+              />
+            ) : (
+              <h1 className="text-2xl font-bold">{questionData.title}</h1>
+            )}
+            <div className="mb-2 mt-4 flex w-full items-center flex-wrap border-b border-gray-300 pb-2 sm:mt-8">
               <p className="w-full text-sm text-gray-600 sm:w-auto">
                 質問者: {questionData.user.name}
               </p>
               <p className="w-full text-sm text-gray-600 sm:ml-6 sm:w-auto">
                 質問日時: {questionData.created_at}
               </p>
-              {/* 将来的に質問を編集する機能ができたら使用 */}
-              {/* <p className="w-full text-sm text-gray-600 sm:ml-6 sm:w-auto">
+              <p className="w-full text-sm text-gray-600 sm:ml-6 sm:w-auto">
                 更新日時: {questionData.updated_at}
-              </p> */}
-            </div>
-            <div className="mb-8">
-              {questionDataTags?.map((tag) => (
-                <Link
-                  key={tag}
-                  href={`${Routes.questions}?tag=${tag.name}`}
-                  className="mr-2 rounded-lg bg-blue-500 px-2.5 py-0.5 text-xs font-semibold text-white"
+              </p>
+              {questionData.status !== "close" && questionData.user.uuid === currentUser.uuid && (
+                <button
+                  type="button"
+                  onClick={handleEdit}
+                  className="rounded border border-slate-700 bg-slate-700 ml-4 px-2 py-1 text-sm text-white transition-all hover:bg-white hover:text-slate-700"
                 >
-                  {tag.name}
-                </Link>
-              ))}
+                  {isEditing ? "戻る" : "編集"}
+                </button>
+              )}
             </div>
-            <div
-              className="znc h-full max-w-[850px] overflow-x-auto p-2"
-              dangerouslySetInnerHTML={{
-                __html: html,
-              }}
-            />
+            <div className="mb-4">
+              {isEditing ? (
+                <div>
+                  <input
+                    type="text"
+                    form="questionEditForm"
+                    name="tags"
+                    defaultValue={questionDataTags
+                      .map((tag) => tag.name)
+                      .join(",")}
+                    className="mt-3 w-full rounded-lg border-gray-200 bg-gray-100 px-4 py-1 text-sm outline-none lg:text-base"
+                  />
+                </div>
+              ) : (
+                <div>
+                  {questionDataTags?.map((tag) => (
+                    <Link
+                      key={tag.name}
+                      href={`${Routes.questions}?tag=${tag.name}`}
+                      className="mr-2 rounded-lg bg-blue-500 px-2.5 py-0.5 text-xs font-semibold text-white"
+                    >
+                      {tag.name}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+            {isEditing ? (
+              <textarea
+                defaultValue={questionData.body}
+                form="questionEditForm"
+                className="resize-none overflow-auto border-none bg-gray-100 p-2 outline-none"
+                rows="12"
+                name="body"
+                onChange={(e) => {
+                  resizeTextArea(e);
+                }}
+              />
+            ) : (
+              <div
+                className="znc h-full max-w-[850px] overflow-x-auto p-2"
+                dangerouslySetInnerHTML={{
+                  __html: html,
+                }}
+              />
+            )}
           </div>
         </div>
+        {isEditing && (
+          <form
+            id="questionEditForm"
+            className="flex w-full flex-col items-center justify-center gap-2"
+            onSubmit={handleSave}
+          >
+            <button
+              type="submit"
+              form="questionEditForm"
+              className="rounded border border-runteq-secondary bg-runteq-secondary px-2 py-1 text-white transition-all hover:bg-white hover:text-runteq-secondary"
+            >
+              更新
+            </button>
+          </form>
+        )}
       </div>
     </div>
   );
-};
+}
 
 export default QuestionDetail;
+

--- a/src/features/questions/components/questionDetail/index.jsx
+++ b/src/features/questions/components/questionDetail/index.jsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useRecoilValue } from "recoil";
+import { mutate } from "swr";
 import markdownToHtml from "zenn-markdown-html";
 import { Routes, Settings } from "@/config";
+import { currentUserState } from "@/features/auth/api";
 import * as Questions from "@/features/questions/components";
 import useFetchData from "@/lib/useFetchData";
-import { currentUserState } from "@/features/auth/api";
-import { useRecoilValue } from "recoil";
 import { resizeTextArea } from "@/utils";
-import { mutate } from "swr";
 
 const QuestionDetail = ({ uuid }) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -38,14 +38,14 @@ const QuestionDetail = ({ uuid }) => {
     e.preventDefault();
     const formData = new FormData(e.target);
     const title = formData.get("title");
-    const tags = formData.get("tags").split(",")
+    const tags = formData.get("tags").split(",");
     const body = formData.get("body");
 
     const updateData = {
       title: title,
       tags: tags,
       body: body,
-    }
+    };
 
     const token = localStorage.getItem("access_token");
     const response = await fetch(`${Settings.API_URL}/questions/${uuid}`, {
@@ -62,12 +62,11 @@ const QuestionDetail = ({ uuid }) => {
       const data = await response.json();
       console.log(data);
       mutate(`${Settings.API_URL}/questions/${uuid}`);
-      mutate(`${Settings.API_URL}/questions/${uuid}/tags`)
+      mutate(`${Settings.API_URL}/questions/${uuid}/tags`);
     } else {
       alert("エラーが発生しました");
     }
   };
-
 
   return (
     <div className="container relative mx-auto p-4">
@@ -91,7 +90,7 @@ const QuestionDetail = ({ uuid }) => {
             ) : (
               <h1 className="text-2xl font-bold">{questionData.title}</h1>
             )}
-            <div className="mb-2 mt-4 flex w-full items-center flex-wrap border-b border-gray-300 pb-2 sm:mt-8">
+            <div className="mb-2 mt-4 flex w-full flex-wrap items-center border-b border-gray-300 pb-2 sm:mt-8">
               <p className="w-full text-sm text-gray-600 sm:w-auto">
                 質問者: {questionData.user.name}
               </p>
@@ -101,15 +100,16 @@ const QuestionDetail = ({ uuid }) => {
               <p className="w-full text-sm text-gray-600 sm:ml-6 sm:w-auto">
                 更新日時: {questionData.updated_at}
               </p>
-              {questionData.status !== "close" && questionData.user.uuid === currentUser.uuid && (
-                <button
-                  type="button"
-                  onClick={handleEdit}
-                  className="rounded border border-slate-700 bg-slate-700 ml-4 px-2 py-1 text-sm text-white transition-all hover:bg-white hover:text-slate-700"
-                >
-                  {isEditing ? "戻る" : "編集"}
-                </button>
-              )}
+              {questionData.status !== "close" &&
+                questionData.user.uuid === currentUser.uuid && (
+                  <button
+                    type="button"
+                    onClick={handleEdit}
+                    className="ml-4 rounded border border-slate-700 bg-slate-700 px-2 py-1 text-sm text-white transition-all hover:bg-white hover:text-slate-700"
+                  >
+                    {isEditing ? "戻る" : "編集"}
+                  </button>
+                )}
             </div>
             <div className="mb-4">
               {isEditing ? (
@@ -177,7 +177,6 @@ const QuestionDetail = ({ uuid }) => {
       </div>
     </div>
   );
-}
+};
 
 export default QuestionDetail;
-


### PR DESCRIPTION
## 概要
質問詳細画面にて投稿の編集を行えるようにしてください

## 目的
質問詳細画面にて質問投稿の編集を行えるようにすることで、ユーザーが誤って記載してしまった際にも修正が可能にするため

## 確認事項

- [x] 画面に編集ボタンが設置されているか
- [x] 編集ボタンによって表示が切り替わるか
- [x] タイトルの変更が可能か
- [x] タグの変更が可能か
- [x] 本文の変更が可能か

## キャプチャ
[![Image from Gyazo](https://i.gyazo.com/4d46e96acb4220e1937e02b16a4e9cd2.gif)](https://gyazo.com/4d46e96acb4220e1937e02b16a4e9cd2)

## 補足
作成に際して、自身の質問である。また、未解決の場合のみ変更が可能になっています。
