### PR TITLE
回答フォームへの調整機能の追加

### DIFF
--- a/src/features/questions/components/commentForms/index.jsx
+++ b/src/features/questions/components/commentForms/index.jsx
@@ -6,6 +6,7 @@ import { Settings } from "@/config";
 import { currentUserState } from "@/features/auth/api";
 import * as Questions from "@/features/questions/components";
 import useFetchData from "@/lib/useFetchData";
+import { resizeTextArea } from "@/utils";
 
 const CommentForm = ({ uuid }) => {
   const router = useRouter();
@@ -109,8 +110,12 @@ const CommentForm = ({ uuid }) => {
             <form onSubmit={handleAnswerSubmit}>
               <textarea
                 value={answer}
-                onChange={(e) => setAnswer(e.target.value)}
-                className="h-32 w-full rounded-lg border bg-gray-100 p-2"
+                rows="5"
+                onChange={(e) => {
+                  resizeTextArea(e);
+                  setAnswer(e.target.value)
+                }}
+                className="w-full rounded-lg border bg-gray-100 p-2"
                 placeholder="コメントを入力"
               ></textarea>
               <button


### PR DESCRIPTION
## 概要
回答フォームにてフォーム幅調整機能の実装を行いました

## 目的
回答フォームにてフォーム幅の調整機能を実装することでユーザーが自分の記載した内容を理解しやすくするため

## 確認事項

- [x] 回答フォームの作成に際して幅の調整が行われているか

## キャプチャ

[![Image from Gyazo](https://i.gyazo.com/a9724cdc6dee05cf98852a7e6bca02f0.gif)](https://gyazo.com/a9724cdc6dee05cf98852a7e6bca02f0)